### PR TITLE
Add basic daily diary web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Daily Vlog
+
+A lightweight personal diary web app. Record a single entry for each day with text, a photo, a short video, and an optional mood tag. Entries are stored locally in your browser so the diary stays private.
+
+## Features
+- Password-protected access.
+- Add/edit one entry per day (photo + video + text).
+- Reverse-chronological timeline.
+- Jump to any date with the calendar picker.
+- Export all entries to a JSON backup.
+- Light/dark theme toggle.
+
+## Usage
+Open `index.html` in a modern browser. The first visit asks you to set a password. After logging in you can create entries and view your timeline.
+
+Data is saved in `localStorage`; clearing browser data removes entries.
+
+## Hosting
+Because the app is a static site it can be hosted on GitHub Pages. Commit the repository and enable Pages on the `main` branch.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Daily Vlog</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="auth" class="modal">
+    <div class="modal-content">
+      <h2 id="auth-title">Set Password</h2>
+      <input type="password" id="password" placeholder="Password" />
+      <button id="auth-btn">Save</button>
+    </div>
+  </div>
+
+  <header>
+    <h1>Daily Vlog</h1>
+    <button id="new-entry">New Entry</button>
+    <input type="date" id="calendar" />
+    <button id="export">Export</button>
+    <button id="theme-toggle">Toggle Theme</button>
+  </header>
+
+  <main id="timeline"></main>
+
+  <div id="entry-modal" class="modal">
+    <div class="modal-content">
+      <h2>New Entry</h2>
+      <textarea id="entry-text" placeholder="How was your day?"></textarea>
+      <div class="media-inputs">
+        <label>Photo: <input type="file" id="entry-photo" accept="image/*" capture="environment" /></label>
+        <label>Video: <input type="file" id="entry-video" accept="video/*" capture="environment" /></label>
+      </div>
+      <label>Mood: <input type="text" id="entry-mood" placeholder="😊" /></label>
+      <div class="modal-actions">
+        <button id="save-entry">Save</button>
+        <button id="cancel-entry">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,143 @@
+function sha256(message) {
+  const msgBuffer = new TextEncoder().encode(message);
+  return crypto.subtle.digest('SHA-256', msgBuffer).then(hashBuffer => {
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  });
+}
+
+function loadEntries() {
+  const data = localStorage.getItem('entries');
+  return data ? JSON.parse(data) : {};
+}
+
+function saveEntries(entries) {
+  localStorage.setItem('entries', JSON.stringify(entries));
+}
+
+function renderTimeline() {
+  const timeline = document.getElementById('timeline');
+  timeline.innerHTML = '';
+  const entries = loadEntries();
+  const dates = Object.keys(entries).sort().reverse();
+  dates.forEach(date => {
+    const entry = entries[date];
+    const div = document.createElement('div');
+    div.className = 'entry';
+    div.id = `entry-${date}`;
+    div.innerHTML = `<h3>${date} ${entry.mood || ''}</h3><p>${entry.text || ''}</p>`;
+    if (entry.photo) {
+      const img = document.createElement('img');
+      img.src = entry.photo;
+      div.appendChild(img);
+    }
+    if (entry.video) {
+      const video = document.createElement('video');
+      video.src = entry.video;
+      video.controls = true;
+      div.appendChild(video);
+    }
+    timeline.appendChild(div);
+  });
+}
+
+function showModal(id) {
+  document.getElementById(id).style.display = 'flex';
+}
+
+function hideModal(id) {
+  document.getElementById(id).style.display = 'none';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const passwordHash = localStorage.getItem('passwordHash');
+  const authTitle = document.getElementById('auth-title');
+  const authBtn = document.getElementById('auth-btn');
+  const authModal = document.getElementById('auth');
+
+  if (!passwordHash) {
+    showModal('auth');
+    authBtn.onclick = async () => {
+      const pwd = document.getElementById('password').value;
+      if (!pwd) return;
+      const hash = await sha256(pwd);
+      localStorage.setItem('passwordHash', hash);
+      hideModal('auth');
+      renderTimeline();
+    };
+  } else {
+    authTitle.textContent = 'Enter Password';
+    authBtn.textContent = 'Login';
+    showModal('auth');
+    authBtn.onclick = async () => {
+      const pwd = document.getElementById('password').value;
+      const hash = await sha256(pwd);
+      if (hash === passwordHash) {
+        hideModal('auth');
+        renderTimeline();
+      } else {
+        alert('Incorrect password');
+      }
+    };
+  }
+
+  document.getElementById('new-entry').onclick = () => {
+    document.getElementById('entry-text').value = '';
+    document.getElementById('entry-photo').value = '';
+    document.getElementById('entry-video').value = '';
+    document.getElementById('entry-mood').value = '';
+    showModal('entry-modal');
+  };
+
+  document.getElementById('cancel-entry').onclick = () => hideModal('entry-modal');
+
+  document.getElementById('save-entry').onclick = () => {
+    const text = document.getElementById('entry-text').value;
+    const mood = document.getElementById('entry-mood').value;
+    const photoFile = document.getElementById('entry-photo').files[0];
+    const videoFile = document.getElementById('entry-video').files[0];
+    const date = new Date().toISOString().slice(0,10);
+    const entries = loadEntries();
+
+    function save(photo, video) {
+      entries[date] = { text, mood, photo, video };
+      saveEntries(entries);
+      hideModal('entry-modal');
+      renderTimeline();
+    }
+
+    const readerPhoto = new FileReader();
+    const readerVideo = new FileReader();
+
+    readerPhoto.onload = e => {
+      const photoData = photoFile ? e.target.result : null;
+      readerVideo.onload = ev => {
+        const videoData = videoFile ? ev.target.result : null;
+        save(photoData, videoData);
+      };
+      if (videoFile) readerVideo.readAsDataURL(videoFile); else readerVideo.onload({target:{result:null}});
+    };
+    if (photoFile) readerPhoto.readAsDataURL(photoFile); else readerPhoto.onload({target:{result:null}});
+  };
+
+  document.getElementById('export').onclick = () => {
+    const data = JSON.stringify(loadEntries());
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'dailyvlog.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  document.getElementById('calendar').onchange = e => {
+    const id = `entry-${e.target.value}`;
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView({behavior:'smooth'});
+  };
+
+  document.getElementById('theme-toggle').onclick = () => {
+    document.body.classList.toggle('dark');
+  };
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,61 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: var(--bg, #fff);
+  color: var(--fg, #000);
+}
+header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 1rem;
+  background: var(--header-bg, #eee);
+}
+#timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+.entry {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 8px;
+  background: var(--entry-bg, #fafafa);
+}
+.entry img, .entry video {
+  max-width: 100%;
+  display: block;
+  margin-top: 0.5rem;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.dark {
+  --bg: #121212;
+  --fg: #eee;
+  --header-bg: #1e1e1e;
+  --entry-bg: #1e1e1e;
+}


### PR DESCRIPTION
## Summary
- Create static "Daily Vlog" diary site with password login, daily entry modal and timeline
- Support text, photo, video, mood tags, date navigation and JSON export
- Add minimal styling with dark mode toggle

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6894aa7a28408324abb90ef2e5a02e89