### PR TITLE
Add Pomodoro timer and local journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# ZHONG
+
+A minimalist web app that combines a Pomodoro-style timer with a private daily journal. All data stays in your browser.
+
+## Features
+
+- 25‑minute focus timer with start, pause, and reset controls
+- Journal entries saved by date in `localStorage`
+- Expand entries to read or edit
+- Calming, responsive layout using the Inter font
+
+## Usage
+
+Open `index.html` in a modern browser. The date field defaults to today; write a reflection and press **Save Entry**. Click past entries to expand or edit them.
+
+Entries and timer data are stored locally in `localStorage`. Clearing browser data removes them. The site can be hosted as static files, e.g. with GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ZHONG</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>ZHONG</h1>
+    <p class="tagline">Focus & Reflect</p>
+  </header>
+
+  <main>
+    <section id="timer">
+      <h2>Pomodoro Timer</h2>
+      <div id="time">25:00</div>
+      <div class="controls">
+        <button id="start">Start</button>
+        <button id="pause">Pause</button>
+        <button id="reset">Reset</button>
+      </div>
+    </section>
+
+    <section id="journal">
+      <h2>Daily Journal</h2>
+      <div class="journal-input">
+        <input type="date" id="entry-date" />
+        <textarea id="entry-text" placeholder="Write your reflection..."></textarea>
+        <button id="save-entry">Save Entry</button>
+      </div>
+      <div id="entries"></div>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,125 @@
+// Timer logic
+const duration = 25 * 60; // 25 minutes
+let remaining = duration;
+let timerId = null;
+
+const timeEl = document.getElementById('time');
+const startBtn = document.getElementById('start');
+const pauseBtn = document.getElementById('pause');
+const resetBtn = document.getElementById('reset');
+
+function updateDisplay() {
+  const mins = String(Math.floor(remaining / 60)).padStart(2, '0');
+  const secs = String(remaining % 60).padStart(2, '0');
+  timeEl.textContent = `${mins}:${secs}`;
+}
+
+function tick() {
+  if (remaining > 0) {
+    remaining--;
+    updateDisplay();
+    if (remaining === 0) {
+      timeEl.classList.add('complete');
+    }
+  } else {
+    clearInterval(timerId);
+    timerId = null;
+  }
+}
+
+startBtn.addEventListener('click', () => {
+  if (timerId) return;
+  timerId = setInterval(tick, 1000);
+});
+
+pauseBtn.addEventListener('click', () => {
+  clearInterval(timerId);
+  timerId = null;
+});
+
+resetBtn.addEventListener('click', () => {
+  clearInterval(timerId);
+  timerId = null;
+  remaining = duration;
+  updateDisplay();
+  timeEl.classList.remove('complete');
+});
+
+updateDisplay();
+
+// Journal logic
+const entryDate = document.getElementById('entry-date');
+const entryText = document.getElementById('entry-text');
+const saveEntry = document.getElementById('save-entry');
+const entriesEl = document.getElementById('entries');
+
+function today() {
+  return new Date().toISOString().split('T')[0];
+}
+
+entryDate.value = today();
+
+saveEntry.addEventListener('click', () => {
+  const date = entryDate.value;
+  const text = entryText.value.trim();
+  if (!date || !text) return;
+  localStorage.setItem('journal-' + date, text);
+  entryText.value = '';
+  renderEntries();
+});
+
+function renderEntries() {
+  entriesEl.innerHTML = '';
+  const keys = Object.keys(localStorage)
+    .filter(k => k.startsWith('journal-'))
+    .sort()
+    .reverse();
+  keys.forEach(key => {
+    const date = key.replace('journal-', '');
+    const text = localStorage.getItem(key) || '';
+    const entry = document.createElement('div');
+    entry.className = 'entry';
+    entry.dataset.date = date;
+
+    const title = document.createElement('h3');
+    title.textContent = formatDate(date);
+    entry.appendChild(title);
+
+    const preview = document.createElement('p');
+    preview.className = 'preview';
+    preview.textContent = text.slice(0, 100) + (text.length > 100 ? '…' : '');
+    entry.appendChild(preview);
+
+    const full = document.createElement('p');
+    full.className = 'full';
+    full.textContent = text;
+    entry.appendChild(full);
+
+    const edit = document.createElement('button');
+    edit.textContent = 'Edit';
+    edit.className = 'edit';
+    entry.appendChild(edit);
+
+    entriesEl.appendChild(entry);
+  });
+}
+
+entriesEl.addEventListener('click', e => {
+  const entry = e.target.closest('.entry');
+  if (!entry) return;
+
+  if (e.target.classList.contains('edit')) {
+    entryDate.value = entry.dataset.date;
+    entryText.value = localStorage.getItem('journal-' + entry.dataset.date) || '';
+    entryText.focus();
+  } else {
+    entry.classList.toggle('expanded');
+  }
+});
+
+function formatDate(str) {
+  const d = new Date(str + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+renderEntries();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,150 @@
+:root {
+  --bg: #f5f7fa;
+  --text: #374151;
+  --accent: #7aa2d2;
+  --card: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
+header {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.tagline {
+  margin-top: 0.25rem;
+  color: #6b7280;
+}
+
+main {
+  width: 90%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem 0;
+}
+
+section {
+  background: var(--card);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+#timer #time {
+  font-size: 3rem;
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+button:hover {
+  opacity: 0.85;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.journal-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 100px;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+#entries .entry {
+  padding: 1rem 0;
+  border-bottom: 1px solid #e5e7eb;
+  cursor: pointer;
+  opacity: 0;
+  animation: fadeIn 0.3s forwards;
+}
+
+#entries .entry:last-child {
+  border-bottom: none;
+}
+
+#entries .entry h3 {
+  margin: 0 0 0.25rem;
+}
+
+#entries .entry .preview {
+  color: #6b7280;
+}
+
+#entries .entry .full {
+  display: none;
+  margin-top: 0.5rem;
+}
+
+#entries .entry.expanded .full {
+  display: block;
+}
+
+#entries .entry button.edit {
+  margin-top: 0.5rem;
+  background: transparent;
+  color: var(--accent);
+  padding: 0;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+#time.complete {
+  color: var(--accent);
+  animation: pulse 1s ease-in-out 2;
+}


### PR DESCRIPTION
## Summary
- Replace previous diary with ZHONG single-page app featuring Pomodoro timer and journal
- Store daily entries in localStorage with expandable edit view
- Apply calming Inter-based theme with fade-in entries and timer completion pulse

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6894aa7a28408324abb90ef2e5a02e89