### PR TITLE
Improve countdown animation and show journal media

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A minimalist web app that combines a Pomodoro-style timer with a private daily j
 - 25‑minute focus timer with start, pause, and reset controls
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
-- Calming, responsive layout using the Inter font
+- Attach images or videos to journal entries
+- Calming, responsive layout with subtle animations using the Inter font
+- Smoothly animated circular countdown with progress ring
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,13 @@
   <main>
     <section id="timer">
       <h2>Pomodoro Timer</h2>
-      <div id="time">25:00</div>
+      <div id="time-wrapper">
+        <svg id="progress" viewBox="0 0 100 100">
+          <circle class="bg" cx="50" cy="50" r="45"></circle>
+          <circle class="bar" cx="50" cy="50" r="45"></circle>
+        </svg>
+        <div id="time">25:00</div>
+      </div>
       <div class="controls">
         <button id="start">Start</button>
         <button id="pause">Pause</button>
@@ -35,6 +41,7 @@
       <div class="journal-input">
         <input type="date" id="entry-date" />
         <textarea id="entry-text" placeholder="Write your reflection..."></textarea>
+        <input type="file" id="entry-media" accept="image/*,video/*" />
         <button id="save-entry">Save Entry</button>
       </div>
       <div id="entries"></div>

--- a/script.js
+++ b/script.js
@@ -1,55 +1,76 @@
 // Timer logic
 const duration = 25 * 60; // 25 minutes
+const totalMs = duration * 1000;
 let remaining = duration;
-let timerId = null;
+let startTime;
+let rafId = null;
+let paused = true;
 
 const timeEl = document.getElementById('time');
+const progressBar = document.querySelector('#progress .bar');
+const circumference = 2 * Math.PI * 45;
+progressBar.style.strokeDasharray = `${circumference}px`;
+
 const startBtn = document.getElementById('start');
 const pauseBtn = document.getElementById('pause');
 const resetBtn = document.getElementById('reset');
 
-function updateDisplay() {
-  const mins = String(Math.floor(remaining / 60)).padStart(2, '0');
-  const secs = String(remaining % 60).padStart(2, '0');
+function updateDisplay(secRemaining) {
+  const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
+  const secs = String(secRemaining % 60).padStart(2, '0');
   timeEl.textContent = `${mins}:${secs}`;
 }
 
-function tick() {
-  if (remaining > 0) {
-    remaining--;
-    updateDisplay();
-    if (remaining === 0) {
-      timeEl.classList.add('complete');
-    }
+function frame(timestamp) {
+  const elapsed = timestamp - startTime;
+  const progress = Math.min(elapsed / totalMs, 1);
+  const secRemaining = Math.ceil((totalMs - elapsed) / 1000);
+
+  progressBar.style.strokeDashoffset = `${circumference * progress}px`;
+
+  if (secRemaining !== remaining) {
+    remaining = secRemaining;
+    updateDisplay(remaining);
+    timeEl.classList.add('tick');
+    setTimeout(() => timeEl.classList.remove('tick'), 150);
+  }
+
+  if (progress < 1) {
+    rafId = requestAnimationFrame(frame);
   } else {
-    clearInterval(timerId);
-    timerId = null;
+    paused = true;
+    timeEl.classList.add('complete');
   }
 }
 
 startBtn.addEventListener('click', () => {
-  if (timerId) return;
-  timerId = setInterval(tick, 1000);
+  if (!paused) return;
+  paused = false;
+  startTime = performance.now() - (duration - remaining) * 1000;
+  rafId = requestAnimationFrame(frame);
 });
 
 pauseBtn.addEventListener('click', () => {
-  clearInterval(timerId);
-  timerId = null;
+  if (paused) return;
+  paused = true;
+  cancelAnimationFrame(rafId);
 });
 
 resetBtn.addEventListener('click', () => {
-  clearInterval(timerId);
-  timerId = null;
+  cancelAnimationFrame(rafId);
+  paused = true;
   remaining = duration;
-  updateDisplay();
+  updateDisplay(remaining);
+  progressBar.style.strokeDashoffset = '0px';
   timeEl.classList.remove('complete');
 });
 
-updateDisplay();
+updateDisplay(remaining);
 
 // Journal logic
 const entryDate = document.getElementById('entry-date');
 const entryText = document.getElementById('entry-text');
+const entryMedia = document.getElementById('entry-media');
 const saveEntry = document.getElementById('save-entry');
 const entriesEl = document.getElementById('entries');
 
@@ -59,14 +80,43 @@ function today() {
 
 entryDate.value = today();
 
-saveEntry.addEventListener('click', () => {
+saveEntry.addEventListener('click', async () => {
   const date = entryDate.value;
   const text = entryText.value.trim();
-  if (!date || !text) return;
-  localStorage.setItem('journal-' + date, text);
-  entryText.value = '';
-  renderEntries();
+  const file = entryMedia.files[0];
+  if (!date || (!text && !file)) return;
+
+  let media, mediaType;
+  if (file) {
+    media = await readFileAsDataURL(file);
+    mediaType = file.type;
+  } else {
+    const existing = JSON.parse(localStorage.getItem('journal-' + date) || '{}');
+    media = existing.media;
+    mediaType = existing.mediaType;
+  }
+
+  const entryObj = { text, media, mediaType };
+  localStorage.setItem('journal-' + date, JSON.stringify(entryObj));
+  afterSave(date);
 });
+
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+function afterSave(date) {
+  entryText.value = '';
+  entryMedia.value = '';
+  renderEntries();
+  const saved = entriesEl.querySelector(`.entry[data-date="${date}"]`);
+  if (saved) saved.classList.add('expanded');
+}
 
 function renderEntries() {
   entriesEl.innerHTML = '';
@@ -76,7 +126,17 @@ function renderEntries() {
     .reverse();
   keys.forEach(key => {
     const date = key.replace('journal-', '');
-    const text = localStorage.getItem(key) || '';
+    const raw = localStorage.getItem(key) || '';
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      data = { text: raw };
+    }
+    const text = data.text || '';
+    const media = data.media;
+    const mediaType = data.mediaType;
+
     const entry = document.createElement('div');
     entry.className = 'entry';
     entry.dataset.date = date;
@@ -87,13 +147,35 @@ function renderEntries() {
 
     const preview = document.createElement('p');
     preview.className = 'preview';
-    preview.textContent = text.slice(0, 100) + (text.length > 100 ? '…' : '');
+    preview.textContent = text
+      ? text.slice(0, 100) + (text.length > 100 ? '…' : '')
+      : '[Media]';
     entry.appendChild(preview);
 
     const full = document.createElement('p');
     full.className = 'full';
     full.textContent = text;
     entry.appendChild(full);
+
+    if (media) {
+      const mediaWrap = document.createElement('div');
+      mediaWrap.className = 'media';
+      let mediaEl;
+      if (mediaType && mediaType.startsWith('video')) {
+        mediaEl = document.createElement('video');
+        mediaEl.controls = true;
+        const source = document.createElement('source');
+        source.src = media;
+        source.type = mediaType || 'video/mp4';
+        mediaEl.appendChild(source);
+      } else {
+        mediaEl = document.createElement('img');
+        mediaEl.alt = 'Journal media';
+        mediaEl.src = media;
+      }
+      mediaWrap.appendChild(mediaEl);
+      entry.appendChild(mediaWrap);
+    }
 
     const edit = document.createElement('button');
     edit.textContent = 'Edit';
@@ -110,7 +192,14 @@ entriesEl.addEventListener('click', e => {
 
   if (e.target.classList.contains('edit')) {
     entryDate.value = entry.dataset.date;
-    entryText.value = localStorage.getItem('journal-' + entry.dataset.date) || '';
+    const raw = localStorage.getItem('journal-' + entry.dataset.date) || '';
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (err) {
+      data = { text: raw };
+    }
+    entryText.value = data.text || '';
     entryText.focus();
   } else {
     entry.classList.toggle('expanded');

--- a/style.css
+++ b/style.css
@@ -28,6 +28,9 @@ body {
 header {
   text-align: center;
   margin-top: 2rem;
+  opacity: 0;
+  animation: fadeInUp 0.6s forwards;
+  animation-delay: 0.1s;
 }
 
 .tagline {
@@ -51,17 +54,58 @@ section {
   border: 1px solid var(--border);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.2s;
+  opacity: 0;
+  animation: fadeInUp 0.6s forwards;
 }
 
 section:hover {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.08);
 }
 
+main > section:nth-of-type(1) {
+  animation-delay: 0.2s;
+}
+
+main > section:nth-of-type(2) {
+  animation-delay: 0.4s;
+}
+
+#time-wrapper {
+  position: relative;
+  width: 150px;
+  height: 150px;
+  margin: 1rem auto;
+}
+
 #timer #time {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   font-size: 3.5rem;
-  text-align: center;
-  margin: 1rem 0;
   font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+#progress {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+#progress circle {
+  fill: none;
+  stroke-width: 8;
+}
+
+#progress circle.bg {
+  stroke: var(--border);
+}
+
+#progress circle.bar {
+  stroke: var(--accent);
+  stroke-dasharray: 282.743px;
+  stroke-dashoffset: 0;
 }
 
 .controls {
@@ -117,6 +161,13 @@ textarea {
   min-height: 100px;
 }
 
+input[type="file"] {
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  font-size: 1rem;
+}
+
 input[type="date"]:focus,
 textarea:focus {
   outline: none;
@@ -129,7 +180,7 @@ textarea:focus {
   border-bottom: 1px solid var(--border);
   cursor: pointer;
   opacity: 0;
-  animation: fadeIn 0.3s forwards;
+  animation: fadeInUp 0.3s forwards;
   transition: background-color 0.2s;
 }
 
@@ -149,13 +200,28 @@ textarea:focus {
   color: #6b7280;
 }
 
-#entries .entry .full {
-  display: none;
+#entries .entry .full,
+#entries .entry .media {
+  max-height: 0;
+  overflow: hidden;
   margin-top: 0.5rem;
+  transition: max-height 0.3s ease;
 }
 
-#entries .entry.expanded .full {
+#entries .entry.expanded .full,
+#entries .entry.expanded .media {
+  max-height: 1000px;
+}
+
+#entries .entry .media img,
+#entries .entry .media video {
   display: block;
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+#entries .entry .media video {
+  max-height: 400px;
 }
 
 #entries .entry button.edit {
@@ -173,19 +239,46 @@ textarea:focus {
   }
 }
 
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes pulse {
   0% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
   }
   50% {
-    transform: scale(1.05);
+    transform: translate(-50%, -50%) scale(1.05);
   }
   100% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes tick {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
   }
 }
 
 #time.complete {
   color: var(--accent);
   animation: pulse 1s ease-in-out 2;
+}
+
+#time.tick {
+  animation: tick 0.5s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- run timer via `requestAnimationFrame` for a smooth circular countdown
- render attached images or videos within expanded journal entries
- document the continuously animated timer

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894ee18679c8324b409094bce871e7a