### PR TITLE
Improve countdown animation and show journal media

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # ZHONG
 
-A minimalist web app that combines a Pomodoro-style timer with a private daily journal. All data stays in your browser.
+A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with a private daily journal. All data stays in your browser.
 
 ## Features
 
 - 25‑minute focus timer with start, pause, and reset controls
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
-- Calming, responsive layout using the Inter font
+- Attach images or videos to journal entries
+- Calming, responsive layout with playful Pokémon styling and subtle animations
+- Smoothly animated circular countdown with progress ring
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
 - Attach images or videos to journal entries
+- Preview selected media before saving entries
 - Calming, responsive layout with playful Pokémon styling and subtle animations
+- Spinning, bouncing Pokéball and scrolling Pokéball background for extra flair
 - Smoothly animated circular countdown with progress ring
 
 ## Usage

--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
 </head>
 <body>
   <header>
-    <div class="pokeball" aria-hidden="true"></div>
+    <div class="pokeball-wrapper">
+      <div class="pokeball" aria-hidden="true"></div>
+    </div>
     <h1>PokéJournal</h1>
     <p class="tagline">Catch your thoughts &amp; train your focus</p>
   </header>
@@ -46,6 +48,7 @@
         <input type="date" id="entry-date" />
         <textarea id="entry-text" placeholder="Write your reflection..."></textarea>
         <input type="file" id="entry-media" accept="image/*,video/*" />
+        <div id="media-preview" class="media-preview" aria-hidden="true"></div>
         <button id="save-entry">Save Entry</button>
       </div>
       <div id="entries"></div>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,32 @@
     name="description"
     content="ZHONG blends a Pomodoro timer with a private daily journal for focused productivity."
   />
-  <title>ZHONG</title>
+  <title>PokéJournal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Press+Start+2P&display=swap"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header>
-    <h1>ZHONG</h1>
-    <p class="tagline">Focus & Reflect</p>
+    <div class="pokeball" aria-hidden="true"></div>
+    <h1>PokéJournal</h1>
+    <p class="tagline">Catch your thoughts &amp; train your focus</p>
   </header>
 
   <main>
     <section id="timer">
       <h2>Pomodoro Timer</h2>
-      <div id="time">25:00</div>
+      <div id="time-wrapper">
+        <svg id="progress" viewBox="0 0 100 100">
+          <circle class="bg" cx="50" cy="50" r="45"></circle>
+          <circle class="bar" cx="50" cy="50" r="45"></circle>
+        </svg>
+        <div id="time">25:00</div>
+      </div>
       <div class="controls">
         <button id="start">Start</button>
         <button id="pause">Pause</button>
@@ -35,6 +45,7 @@
       <div class="journal-input">
         <input type="date" id="entry-date" />
         <textarea id="entry-text" placeholder="Write your reflection..."></textarea>
+        <input type="file" id="entry-media" accept="image/*,video/*" />
         <button id="save-entry">Save Entry</button>
       </div>
       <div id="entries"></div>

--- a/script.js
+++ b/script.js
@@ -73,6 +73,7 @@ const entryText = document.getElementById('entry-text');
 const entryMedia = document.getElementById('entry-media');
 const saveEntry = document.getElementById('save-entry');
 const entriesEl = document.getElementById('entries');
+const mediaPreview = document.getElementById('media-preview');
 
 function today() {
   return new Date().toISOString().split('T')[0];
@@ -101,6 +102,25 @@ saveEntry.addEventListener('click', async () => {
   afterSave(date);
 });
 
+entryMedia.addEventListener('change', () => {
+  const file = entryMedia.files[0];
+  mediaPreview.innerHTML = '';
+  mediaPreview.classList.remove('show');
+  if (!file) return;
+  const url = URL.createObjectURL(file);
+  let el;
+  if (file.type.startsWith('video')) {
+    el = document.createElement('video');
+    el.controls = true;
+  } else {
+    el = document.createElement('img');
+    el.alt = 'Selected media preview';
+  }
+  el.src = url;
+  mediaPreview.appendChild(el);
+  mediaPreview.classList.add('show');
+});
+
 function readFileAsDataURL(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -113,6 +133,8 @@ function readFileAsDataURL(file) {
 function afterSave(date) {
   entryText.value = '';
   entryMedia.value = '';
+  mediaPreview.innerHTML = '';
+  mediaPreview.classList.remove('show');
   renderEntries();
   const saved = entriesEl.querySelector(`.entry[data-date="${date}"]`);
   if (saved) saved.classList.add('expanded');

--- a/script.js
+++ b/script.js
@@ -1,55 +1,76 @@
 // Timer logic
 const duration = 25 * 60; // 25 minutes
+const totalMs = duration * 1000;
 let remaining = duration;
-let timerId = null;
+let startTime;
+let rafId = null;
+let paused = true;
 
 const timeEl = document.getElementById('time');
+const progressBar = document.querySelector('#progress .bar');
+const circumference = 2 * Math.PI * 45;
+progressBar.style.strokeDasharray = `${circumference}px`;
+
 const startBtn = document.getElementById('start');
 const pauseBtn = document.getElementById('pause');
 const resetBtn = document.getElementById('reset');
 
-function updateDisplay() {
-  const mins = String(Math.floor(remaining / 60)).padStart(2, '0');
-  const secs = String(remaining % 60).padStart(2, '0');
+function updateDisplay(secRemaining) {
+  const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
+  const secs = String(secRemaining % 60).padStart(2, '0');
   timeEl.textContent = `${mins}:${secs}`;
 }
 
-function tick() {
-  if (remaining > 0) {
-    remaining--;
-    updateDisplay();
-    if (remaining === 0) {
-      timeEl.classList.add('complete');
-    }
+function frame(timestamp) {
+  const elapsed = timestamp - startTime;
+  const progress = Math.min(elapsed / totalMs, 1);
+  const secRemaining = Math.ceil((totalMs - elapsed) / 1000);
+
+  progressBar.style.strokeDashoffset = `${circumference * progress}px`;
+
+  if (secRemaining !== remaining) {
+    remaining = secRemaining;
+    updateDisplay(remaining);
+    timeEl.classList.add('tick');
+    setTimeout(() => timeEl.classList.remove('tick'), 150);
+  }
+
+  if (progress < 1) {
+    rafId = requestAnimationFrame(frame);
   } else {
-    clearInterval(timerId);
-    timerId = null;
+    paused = true;
+    timeEl.classList.add('complete');
   }
 }
 
 startBtn.addEventListener('click', () => {
-  if (timerId) return;
-  timerId = setInterval(tick, 1000);
+  if (!paused) return;
+  paused = false;
+  startTime = performance.now() - (duration - remaining) * 1000;
+  rafId = requestAnimationFrame(frame);
 });
 
 pauseBtn.addEventListener('click', () => {
-  clearInterval(timerId);
-  timerId = null;
+  if (paused) return;
+  paused = true;
+  cancelAnimationFrame(rafId);
 });
 
 resetBtn.addEventListener('click', () => {
-  clearInterval(timerId);
-  timerId = null;
+  cancelAnimationFrame(rafId);
+  paused = true;
   remaining = duration;
-  updateDisplay();
+  updateDisplay(remaining);
+  progressBar.style.strokeDashoffset = '0px';
   timeEl.classList.remove('complete');
 });
 
-updateDisplay();
+updateDisplay(remaining);
 
 // Journal logic
 const entryDate = document.getElementById('entry-date');
 const entryText = document.getElementById('entry-text');
+const entryMedia = document.getElementById('entry-media');
 const saveEntry = document.getElementById('save-entry');
 const entriesEl = document.getElementById('entries');
 
@@ -59,14 +80,43 @@ function today() {
 
 entryDate.value = today();
 
-saveEntry.addEventListener('click', () => {
+saveEntry.addEventListener('click', async () => {
   const date = entryDate.value;
   const text = entryText.value.trim();
-  if (!date || !text) return;
-  localStorage.setItem('journal-' + date, text);
-  entryText.value = '';
-  renderEntries();
+  const file = entryMedia.files[0];
+  if (!date || (!text && !file)) return;
+
+  let media, mediaType;
+  if (file) {
+    media = await readFileAsDataURL(file);
+    mediaType = file.type;
+  } else {
+    const existing = JSON.parse(localStorage.getItem('journal-' + date) || '{}');
+    media = existing.media;
+    mediaType = existing.mediaType;
+  }
+
+  const entryObj = { text, media, mediaType };
+  localStorage.setItem('journal-' + date, JSON.stringify(entryObj));
+  afterSave(date);
 });
+
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+function afterSave(date) {
+  entryText.value = '';
+  entryMedia.value = '';
+  renderEntries();
+  const saved = entriesEl.querySelector(`.entry[data-date="${date}"]`);
+  if (saved) saved.classList.add('expanded');
+}
 
 function renderEntries() {
   entriesEl.innerHTML = '';
@@ -76,7 +126,17 @@ function renderEntries() {
     .reverse();
   keys.forEach(key => {
     const date = key.replace('journal-', '');
-    const text = localStorage.getItem(key) || '';
+    const raw = localStorage.getItem(key) || '';
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      data = { text: raw };
+    }
+    const text = data.text || '';
+    const media = data.media;
+    const mediaType = data.mediaType;
+
     const entry = document.createElement('div');
     entry.className = 'entry';
     entry.dataset.date = date;
@@ -87,13 +147,35 @@ function renderEntries() {
 
     const preview = document.createElement('p');
     preview.className = 'preview';
-    preview.textContent = text.slice(0, 100) + (text.length > 100 ? '…' : '');
+    preview.textContent = text
+      ? text.slice(0, 100) + (text.length > 100 ? '…' : '')
+      : '[Media]';
     entry.appendChild(preview);
 
     const full = document.createElement('p');
     full.className = 'full';
     full.textContent = text;
     entry.appendChild(full);
+
+    if (media) {
+      const mediaWrap = document.createElement('div');
+      mediaWrap.className = 'media';
+      let mediaEl;
+      if (mediaType && mediaType.startsWith('video')) {
+        mediaEl = document.createElement('video');
+        mediaEl.controls = true;
+        const source = document.createElement('source');
+        source.src = media;
+        source.type = mediaType || 'video/mp4';
+        mediaEl.appendChild(source);
+      } else {
+        mediaEl = document.createElement('img');
+        mediaEl.alt = 'Journal media';
+        mediaEl.src = media;
+      }
+      mediaWrap.appendChild(mediaEl);
+      entry.appendChild(mediaWrap);
+    }
 
     const edit = document.createElement('button');
     edit.textContent = 'Edit';
@@ -110,7 +192,14 @@ entriesEl.addEventListener('click', e => {
 
   if (e.target.classList.contains('edit')) {
     entryDate.value = entry.dataset.date;
-    entryText.value = localStorage.getItem('journal-' + entry.dataset.date) || '';
+    const raw = localStorage.getItem('journal-' + entry.dataset.date) || '';
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (err) {
+      data = { text: raw };
+    }
+    entryText.value = data.text || '';
     entryText.focus();
   } else {
     entry.classList.toggle('expanded');

--- a/style.css
+++ b/style.css
@@ -16,7 +16,11 @@
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
-  background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
+  background:
+    linear-gradient(135deg, var(--bg-start), var(--bg-end)),
+    radial-gradient(circle at 20px 20px, #fff 0 9px, #000 9px 10px, var(--accent) 10px 19px, #000 19px 20px);
+  background-size: 100% 100%, 40px 40px;
+  animation: scrollBg 30s linear infinite;
   color: var(--text);
   line-height: 1.6;
   display: flex;
@@ -45,15 +49,21 @@ h2 {
   margin-top: 0;
 }
 
-.pokeball {
+.pokeball-wrapper {
   width: 60px;
   height: 60px;
+  margin: 0 auto 1rem;
+  animation: bounce 1.5s ease-in-out infinite;
+}
+
+.pokeball {
+  width: 100%;
+  height: 100%;
   border: 4px solid #000;
   border-radius: 50%;
   position: relative;
   overflow: hidden;
   background: linear-gradient(to bottom, var(--accent) 50%, #fff 50%);
-  margin: 0 auto 1rem;
   animation: spin 3s linear infinite;
 }
 
@@ -170,8 +180,9 @@ button {
   padding: 0.5rem 1.25rem;
   border-radius: 6px;
   cursor: pointer;
-  font-weight: 600;
-  letter-spacing: 0.3px;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 0.75rem;
+  letter-spacing: 0.5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: background 0.2s, transform 0.1s;
 }
@@ -215,6 +226,23 @@ input[type="file"] {
   border-radius: 6px;
   padding: 0.75rem;
   font-size: 1rem;
+}
+
+.media-preview {
+  display: none;
+  margin-top: 0.5rem;
+  animation: fadeIn 0.4s ease forwards;
+}
+
+.media-preview.show {
+  display: block;
+}
+
+.media-preview img,
+.media-preview video {
+  max-width: 100%;
+  border-radius: 8px;
+  border: 2px solid #000;
 }
 
 input[type="date"]:focus,
@@ -338,5 +366,23 @@ textarea:focus {
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes scrollBg {
+  from {
+    background-position: 0 0, 0 0;
+  }
+  to {
+    background-position: 0 0, 40px 40px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 :root {
-  --bg-start: #f5f7fa;
-  --bg-end: #e1e8f0;
-  --text: #374151;
-  --accent: #6366f1;
-  --accent-hover: #4f46e5;
+  --bg-start: #fff8e1;
+  --bg-end: #ffe5e5;
+  --text: #1f2937;
+  --accent: #ef4444;
+  --accent-hover: #dc2626;
   --card: #ffffff;
   --border: #e5e7eb;
+  --complete: #ffcb05;
 }
 
 * {
@@ -28,11 +29,62 @@ body {
 header {
   text-align: center;
   margin-top: 2rem;
+  opacity: 0;
+  animation: fadeInUp 0.6s forwards;
+  animation-delay: 0.1s;
+  position: relative;
+}
+
+header h1 {
+  font-family: 'Press Start 2P', cursive;
+  margin-bottom: 0.5rem;
+}
+
+h2 {
+  font-family: 'Press Start 2P', cursive;
+  margin-top: 0;
+}
+
+.pokeball {
+  width: 60px;
+  height: 60px;
+  border: 4px solid #000;
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(to bottom, var(--accent) 50%, #fff 50%);
+  margin: 0 auto 1rem;
+  animation: spin 3s linear infinite;
+}
+
+.pokeball::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 24px;
+  height: 24px;
+  background: #fff;
+  border: 4px solid #000;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+}
+
+.pokeball::after {
+  content: '';
+  position: absolute;
+  top: calc(50% - 2px);
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #000;
+  z-index: 1;
 }
 
 .tagline {
   margin-top: 0.25rem;
-  color: #6b7280;
+  color: var(--accent);
 }
 
 main {
@@ -48,20 +100,61 @@ section {
   background: var(--card);
   padding: 1.75rem;
   border-radius: 12px;
-  border: 1px solid var(--border);
+  border: 2px solid #000;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.2s;
+  opacity: 0;
+  animation: fadeInUp 0.6s forwards;
 }
 
 section:hover {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.08);
 }
 
+main > section:nth-of-type(1) {
+  animation-delay: 0.2s;
+}
+
+main > section:nth-of-type(2) {
+  animation-delay: 0.4s;
+}
+
+#time-wrapper {
+  position: relative;
+  width: 150px;
+  height: 150px;
+  margin: 1rem auto;
+}
+
 #timer #time {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   font-size: 3.5rem;
-  text-align: center;
-  margin: 1rem 0;
   font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+#progress {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+#progress circle {
+  fill: none;
+  stroke-width: 8;
+}
+
+#progress circle.bg {
+  stroke: #000;
+}
+
+#progress circle.bar {
+  stroke: var(--accent);
+  stroke-dasharray: 282.743px;
+  stroke-dashoffset: 0;
 }
 
 .controls {
@@ -73,7 +166,7 @@ section:hover {
 button {
   background: var(--accent);
   color: #fff;
-  border: none;
+  border: 2px solid #000;
   padding: 0.5rem 1.25rem;
   border-radius: 6px;
   cursor: pointer;
@@ -117,6 +210,13 @@ textarea {
   min-height: 100px;
 }
 
+input[type="file"] {
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  font-size: 1rem;
+}
+
 input[type="date"]:focus,
 textarea:focus {
   outline: none;
@@ -129,7 +229,7 @@ textarea:focus {
   border-bottom: 1px solid var(--border);
   cursor: pointer;
   opacity: 0;
-  animation: fadeIn 0.3s forwards;
+  animation: fadeInUp 0.3s forwards;
   transition: background-color 0.2s;
 }
 
@@ -149,13 +249,28 @@ textarea:focus {
   color: #6b7280;
 }
 
-#entries .entry .full {
-  display: none;
+#entries .entry .full,
+#entries .entry .media {
+  max-height: 0;
+  overflow: hidden;
   margin-top: 0.5rem;
+  transition: max-height 0.3s ease;
 }
 
-#entries .entry.expanded .full {
+#entries .entry.expanded .full,
+#entries .entry.expanded .media {
+  max-height: 1000px;
+}
+
+#entries .entry .media img,
+#entries .entry .media video {
   display: block;
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+#entries .entry .media video {
+  max-height: 400px;
 }
 
 #entries .entry button.edit {
@@ -173,19 +288,55 @@ textarea:focus {
   }
 }
 
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes pulse {
   0% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
   }
   50% {
-    transform: scale(1.05);
+    transform: translate(-50%, -50%) scale(1.05);
   }
   100% {
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes tick {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
   }
 }
 
 #time.complete {
-  color: var(--accent);
+  color: var(--complete);
   animation: pulse 1s ease-in-out 2;
+}
+
+#time.tick {
+  animation: tick 0.5s ease-in-out;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Summary
- run timer via `requestAnimationFrame` for a smooth circular countdown
- render attached images or videos within expanded journal entries
- document the continuously animated timer

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894ee18679c8324b409094bce871e7a