### PR TITLE
feat: persist timer settings and capture more pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 
 ## Features
 
-- Adjustable focus timer with default 25‑minute sessions and 5‑minute breaks
+- Adjustable focus timer with work/break lengths saved between sessions
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
 - Attach images or videos to journal entries
@@ -12,7 +12,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 - See existing attachments when editing entries
 - Delete entries or edit them later
 - Confetti celebration when the timer completes
-- Capture a random Pokémon in your Pokédex at the end of each session
+- Capture a random Pokémon in your Pokédex every time the timer finishes
 - Calming, responsive layout with playful Pokémon styling and subtle animations
 - Spinning, bouncing Pokéball and scrolling Pokéball background for extra flair
 - A running Pikachu sprite dashes across the page

--- a/script.js
+++ b/script.js
@@ -20,6 +20,21 @@ const resetBtn = document.getElementById('reset');
 const workInput = document.getElementById('work-duration');
 const breakInput = document.getElementById('break-duration');
 
+// Load saved durations or fall back to defaults
+const savedWork = parseInt(localStorage.getItem('work-duration'), 10);
+const savedBreak = parseInt(localStorage.getItem('break-duration'), 10);
+if (!isNaN(savedWork)) {
+  workDuration = savedWork * 60;
+  workInput.value = savedWork;
+}
+if (!isNaN(savedBreak)) {
+  breakDuration = savedBreak * 60;
+  breakInput.value = savedBreak;
+}
+duration = workDuration;
+remaining = duration;
+totalMs = duration * 1000;
+
 function updateDisplay(secRemaining) {
   const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
   const secs = String(secRemaining % 60).padStart(2, '0');
@@ -45,9 +60,9 @@ function frame(timestamp) {
   } else {
     paused = true;
     timeEl.classList.add('complete');
+    capturePokemon();
     if (!isBreak) {
       launchConfetti();
-      capturePokemon();
       isBreak = true;
       duration = breakDuration;
       remaining = duration;
@@ -98,6 +113,8 @@ resetBtn.addEventListener('click', () => {
 function applyDurations() {
   workDuration = Math.max(parseInt(workInput.value, 10) || 1, 1) * 60;
   breakDuration = Math.max(parseInt(breakInput.value, 10) || 1, 1) * 60;
+  localStorage.setItem('work-duration', workInput.value);
+  localStorage.setItem('break-duration', breakInput.value);
   if (!isBreak) {
     duration = workDuration;
   } else {


### PR DESCRIPTION
## Summary
- persist custom Pomodoro work/break durations in localStorage so they become the defaults
- capture a new random Pokémon whenever any timer session finishes
- document persistent timer settings and per-session captures in README

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895097a2da0832499004df86c7b355e