### PR TITLE
feat: persist timer settings with dropdown and capture more pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 
 ## Features
 
-- Adjustable focus timer with default 25‑minute sessions and 5‑minute breaks
+- Adjustable focus timer with work/break lengths selectable from dropdown and saved between sessions
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
 - Attach images or videos to journal entries
@@ -12,7 +12,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 - See existing attachments when editing entries
 - Delete entries or edit them later
 - Confetti celebration when the timer completes
-- Capture a random Pokémon in your Pokédex at the end of each session
+- Capture a random Pokémon in your Pokédex every time the timer finishes
 - Calming, responsive layout with playful Pokémon styling and subtle animations
 - Spinning, bouncing Pokéball and scrolling Pokéball background for extra flair
 - A running Pikachu sprite dashes across the page

--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@
       </div>
       <div class="duration-settings">
         <label>Work (min)
-          <input type="number" id="work-duration" value="25" min="1" />
+          <select id="work-duration"></select>
         </label>
         <label>Break (min)
-          <input type="number" id="break-duration" value="5" min="1" />
+          <select id="break-duration"></select>
         </label>
       </div>
       <div class="controls">

--- a/script.js
+++ b/script.js
@@ -20,6 +20,34 @@ const resetBtn = document.getElementById('reset');
 const workInput = document.getElementById('work-duration');
 const breakInput = document.getElementById('break-duration');
 
+function populateDropdown(select, defaultValue) {
+  for (let i = 1; i <= 60; i++) {
+    const option = document.createElement('option');
+    option.value = i;
+    option.textContent = i;
+    select.appendChild(option);
+  }
+  select.value = defaultValue;
+}
+
+populateDropdown(workInput, 25);
+populateDropdown(breakInput, 5);
+
+// Load saved durations or fall back to defaults
+const savedWork = parseInt(localStorage.getItem('work-duration'), 10);
+const savedBreak = parseInt(localStorage.getItem('break-duration'), 10);
+if (!isNaN(savedWork)) {
+  workDuration = savedWork * 60;
+  workInput.value = savedWork;
+}
+if (!isNaN(savedBreak)) {
+  breakDuration = savedBreak * 60;
+  breakInput.value = savedBreak;
+}
+duration = workDuration;
+remaining = duration;
+totalMs = duration * 1000;
+
 function updateDisplay(secRemaining) {
   const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
   const secs = String(secRemaining % 60).padStart(2, '0');
@@ -45,9 +73,9 @@ function frame(timestamp) {
   } else {
     paused = true;
     timeEl.classList.add('complete');
+    capturePokemon();
     if (!isBreak) {
       launchConfetti();
-      capturePokemon();
       isBreak = true;
       duration = breakDuration;
       remaining = duration;
@@ -98,6 +126,8 @@ resetBtn.addEventListener('click', () => {
 function applyDurations() {
   workDuration = Math.max(parseInt(workInput.value, 10) || 1, 1) * 60;
   breakDuration = Math.max(parseInt(breakInput.value, 10) || 1, 1) * 60;
+  localStorage.setItem('work-duration', workInput.value);
+  localStorage.setItem('break-duration', breakInput.value);
   if (!isBreak) {
     duration = workDuration;
   } else {


### PR DESCRIPTION
## Summary
- allow selecting work and break minutes from dropdowns
- selections persist across sessions using localStorage
- capture a new random Pokémon every time any timer completes

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895097a2da0832499004df86c7b355e