### PR TITLE
feat: persist timer settings with dropdown and capture more pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZHONG
+# PokéJournal
 
 A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with a private daily journal. All data stays in your browser.
 
@@ -13,6 +13,8 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 - Delete entries or edit them later
 - Confetti celebration when the timer completes
 - Capture a random Pokémon in your Pokédex every time the timer finishes
+- Track total focused minutes and session count below the timer
+- Popup and optional browser notification announce each Pokémon you catch
 - Calming, responsive layout with playful Pokémon styling and subtle animations
 - Spinning, bouncing Pokéball and scrolling Pokéball background for extra flair
 - A running Pikachu sprite dashes across the page
@@ -24,23 +26,3 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 Open `index.html` in a modern browser. The date field defaults to today; write a reflection and press **Save Entry**. Click past entries to expand or edit them.
 
 Entries and timer data are stored locally in `localStorage`. Clearing browser data removes them. The site can be hosted as static files, e.g. with GitHub Pages.
-=======
-# Daily Vlog
-
-A lightweight personal diary web app. Record a single entry for each day with text, a photo, a short video, and an optional mood tag. Entries are stored locally in your browser so the diary stays private.
-
-## Features
-- Password-protected access.
-- Add/edit one entry per day (photo + video + text).
-- Reverse-chronological timeline.
-- Jump to any date with the calendar picker.
-- Export all entries to a JSON backup.
-- Light/dark theme toggle.
-
-## Usage
-Open `index.html` in a modern browser. The first visit asks you to set a password. After logging in you can create entries and view your timeline.
-
-Data is saved in `localStorage`; clearing browser data removes entries.
-
-## Hosting
-Because the app is a static site it can be hosted on GitHub Pages. Commit the repository and enable Pages on the `main` branch.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 
 ## Features
 
-- Adjustable focus timer with default 25‑minute sessions and 5‑minute breaks
+- Adjustable focus timer with work/break lengths selectable from dropdown and saved between sessions
 - Journal entries saved by date in `localStorage`
 - Expand entries to read or edit
 - Attach images or videos to journal entries
@@ -12,7 +12,7 @@ A minimalist, Pokémon-themed web app that combines a Pomodoro-style timer with 
 - See existing attachments when editing entries
 - Delete entries or edit them later
 - Confetti celebration when the timer completes
-- Capture a random Pokémon in your Pokédex at the end of each session
+- Capture a random Pokémon in your Pokédex every time the timer finishes
 - Calming, responsive layout with playful Pokémon styling and subtle animations
 - Spinning, bouncing Pokéball and scrolling Pokéball background for extra flair
 - A running Pikachu sprite dashes across the page

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta
     name="description"
-    content="ZHONG blends a Pomodoro timer with a private daily journal for focused productivity."
+    content="PokéJournal blends a Pomodoro timer with a private daily journal for focused productivity."
   />
   <title>PokéJournal</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -49,6 +49,10 @@
         <button id="pause">Pause</button>
         <button id="reset">Reset</button>
       </div>
+      <div class="stats">
+        <p>Total Focus: <span id="total-focus">0</span> min</p>
+        <p>Sessions: <span id="session-count">0</span></p>
+      </div>
     </section>
 
     <section id="pokedex">
@@ -69,45 +73,6 @@
       <div id="entries"></div>
     </section>
   </main>
-=======
-  <title>Daily Vlog</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <div id="auth" class="modal">
-    <div class="modal-content">
-      <h2 id="auth-title">Set Password</h2>
-      <input type="password" id="password" placeholder="Password" />
-      <button id="auth-btn">Save</button>
-    </div>
-  </div>
-
-  <header>
-    <h1>Daily Vlog</h1>
-    <button id="new-entry">New Entry</button>
-    <input type="date" id="calendar" />
-    <button id="export">Export</button>
-    <button id="theme-toggle">Toggle Theme</button>
-  </header>
-
-  <main id="timeline"></main>
-
-  <div id="entry-modal" class="modal">
-    <div class="modal-content">
-      <h2>New Entry</h2>
-      <textarea id="entry-text" placeholder="How was your day?"></textarea>
-      <div class="media-inputs">
-        <label>Photo: <input type="file" id="entry-photo" accept="image/*" capture="environment" /></label>
-        <label>Video: <input type="file" id="entry-video" accept="video/*" capture="environment" /></label>
-      </div>
-      <label>Mood: <input type="text" id="entry-mood" placeholder="😊" /></label>
-      <div class="modal-actions">
-        <button id="save-entry">Save</button>
-        <button id="cancel-entry">Cancel</button>
-      </div>
-    </div>
-  </div>
-
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@
       </div>
       <div class="duration-settings">
         <label>Work (min)
-          <input type="number" id="work-duration" value="25" min="1" />
+          <select id="work-duration"></select>
         </label>
         <label>Break (min)
-          <input type="number" id="break-duration" value="5" min="1" />
+          <select id="break-duration"></select>
         </label>
       </div>
       <div class="controls">

--- a/script.js
+++ b/script.js
@@ -19,6 +19,16 @@ const pauseBtn = document.getElementById('pause');
 const resetBtn = document.getElementById('reset');
 const workInput = document.getElementById('work-duration');
 const breakInput = document.getElementById('break-duration');
+const totalFocusEl = document.getElementById('total-focus');
+const sessionCountEl = document.getElementById('session-count');
+
+let totalFocus = parseInt(localStorage.getItem('total-focus'), 10) || 0;
+let sessionCount = parseInt(localStorage.getItem('session-count'), 10) || 0;
+
+function renderStats() {
+  if (totalFocusEl) totalFocusEl.textContent = totalFocus;
+  if (sessionCountEl) sessionCountEl.textContent = sessionCount;
+}
 
 function populateDropdown(select, defaultValue) {
   for (let i = 1; i <= 60; i++) {
@@ -75,6 +85,11 @@ function frame(timestamp) {
     timeEl.classList.add('complete');
     capturePokemon();
     if (!isBreak) {
+      totalFocus += workDuration / 60;
+      sessionCount += 1;
+      localStorage.setItem('total-focus', totalFocus);
+      localStorage.setItem('session-count', sessionCount);
+      renderStats();
       launchConfetti();
       isBreak = true;
       duration = breakDuration;
@@ -146,6 +161,7 @@ workInput.addEventListener('change', applyDurations);
 breakInput.addEventListener('change', applyDurations);
 
 updateDisplay(remaining);
+renderStats();
 
 // Journal logic
 const entryDate = document.getElementById('entry-date');
@@ -378,9 +394,21 @@ async function capturePokemon() {
     captured.push(pokemon);
     localStorage.setItem('captured-pokemon', JSON.stringify(captured));
     renderCaptured();
+    showCaptureToast(pokemon.name);
+    if ('Notification' in window && Notification.permission === 'granted') {
+      new Notification(`You caught ${pokemon.name}!`);
+    }
   } catch (e) {
     console.error('Could not capture Pokémon', e);
   }
+}
+
+function showCaptureToast(name) {
+  const div = document.createElement('div');
+  div.className = 'capture-toast';
+  div.textContent = `You caught ${name}!`;
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 3000);
 }
 
 function renderCaptured() {
@@ -399,146 +427,6 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('sw.js');
 }
 
-function sha256(message) {
-  const msgBuffer = new TextEncoder().encode(message);
-  return crypto.subtle.digest('SHA-256', msgBuffer).then(hashBuffer => {
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-  });
+if ('Notification' in window && Notification.permission === 'default') {
+  Notification.requestPermission();
 }
-
-function loadEntries() {
-  const data = localStorage.getItem('entries');
-  return data ? JSON.parse(data) : {};
-}
-
-function saveEntries(entries) {
-  localStorage.setItem('entries', JSON.stringify(entries));
-}
-
-function renderTimeline() {
-  const timeline = document.getElementById('timeline');
-  timeline.innerHTML = '';
-  const entries = loadEntries();
-  const dates = Object.keys(entries).sort().reverse();
-  dates.forEach(date => {
-    const entry = entries[date];
-    const div = document.createElement('div');
-    div.className = 'entry';
-    div.id = `entry-${date}`;
-    div.innerHTML = `<h3>${date} ${entry.mood || ''}</h3><p>${entry.text || ''}</p>`;
-    if (entry.photo) {
-      const img = document.createElement('img');
-      img.src = entry.photo;
-      div.appendChild(img);
-    }
-    if (entry.video) {
-      const video = document.createElement('video');
-      video.src = entry.video;
-      video.controls = true;
-      div.appendChild(video);
-    }
-    timeline.appendChild(div);
-  });
-}
-
-function showModal(id) {
-  document.getElementById(id).style.display = 'flex';
-}
-
-function hideModal(id) {
-  document.getElementById(id).style.display = 'none';
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  const passwordHash = localStorage.getItem('passwordHash');
-  const authTitle = document.getElementById('auth-title');
-  const authBtn = document.getElementById('auth-btn');
-  const authModal = document.getElementById('auth');
-
-  if (!passwordHash) {
-    showModal('auth');
-    authBtn.onclick = async () => {
-      const pwd = document.getElementById('password').value;
-      if (!pwd) return;
-      const hash = await sha256(pwd);
-      localStorage.setItem('passwordHash', hash);
-      hideModal('auth');
-      renderTimeline();
-    };
-  } else {
-    authTitle.textContent = 'Enter Password';
-    authBtn.textContent = 'Login';
-    showModal('auth');
-    authBtn.onclick = async () => {
-      const pwd = document.getElementById('password').value;
-      const hash = await sha256(pwd);
-      if (hash === passwordHash) {
-        hideModal('auth');
-        renderTimeline();
-      } else {
-        alert('Incorrect password');
-      }
-    };
-  }
-
-  document.getElementById('new-entry').onclick = () => {
-    document.getElementById('entry-text').value = '';
-    document.getElementById('entry-photo').value = '';
-    document.getElementById('entry-video').value = '';
-    document.getElementById('entry-mood').value = '';
-    showModal('entry-modal');
-  };
-
-  document.getElementById('cancel-entry').onclick = () => hideModal('entry-modal');
-
-  document.getElementById('save-entry').onclick = () => {
-    const text = document.getElementById('entry-text').value;
-    const mood = document.getElementById('entry-mood').value;
-    const photoFile = document.getElementById('entry-photo').files[0];
-    const videoFile = document.getElementById('entry-video').files[0];
-    const date = new Date().toISOString().slice(0,10);
-    const entries = loadEntries();
-
-    function save(photo, video) {
-      entries[date] = { text, mood, photo, video };
-      saveEntries(entries);
-      hideModal('entry-modal');
-      renderTimeline();
-    }
-
-    const readerPhoto = new FileReader();
-    const readerVideo = new FileReader();
-
-    readerPhoto.onload = e => {
-      const photoData = photoFile ? e.target.result : null;
-      readerVideo.onload = ev => {
-        const videoData = videoFile ? ev.target.result : null;
-        save(photoData, videoData);
-      };
-      if (videoFile) readerVideo.readAsDataURL(videoFile); else readerVideo.onload({target:{result:null}});
-    };
-    if (photoFile) readerPhoto.readAsDataURL(photoFile); else readerPhoto.onload({target:{result:null}});
-  };
-
-  document.getElementById('export').onclick = () => {
-    const data = JSON.stringify(loadEntries());
-    const blob = new Blob([data], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'dailyvlog.json';
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  document.getElementById('calendar').onchange = e => {
-    const id = `entry-${e.target.value}`;
-    const el = document.getElementById(id);
-    if (el) el.scrollIntoView({behavior:'smooth'});
-  };
-
-  document.getElementById('theme-toggle').onclick = () => {
-    document.body.classList.toggle('dark');
-  };
-});

--- a/script.js
+++ b/script.js
@@ -20,6 +20,34 @@ const resetBtn = document.getElementById('reset');
 const workInput = document.getElementById('work-duration');
 const breakInput = document.getElementById('break-duration');
 
+function populateDropdown(select, defaultValue) {
+  for (let i = 1; i <= 60; i++) {
+    const option = document.createElement('option');
+    option.value = i;
+    option.textContent = i;
+    select.appendChild(option);
+  }
+  select.value = defaultValue;
+}
+
+populateDropdown(workInput, 25);
+populateDropdown(breakInput, 5);
+
+// Load saved durations or fall back to defaults
+const savedWork = parseInt(localStorage.getItem('work-duration'), 10);
+const savedBreak = parseInt(localStorage.getItem('break-duration'), 10);
+if (!isNaN(savedWork)) {
+  workDuration = savedWork * 60;
+  workInput.value = savedWork;
+}
+if (!isNaN(savedBreak)) {
+  breakDuration = savedBreak * 60;
+  breakInput.value = savedBreak;
+}
+duration = workDuration;
+remaining = duration;
+totalMs = duration * 1000;
+
 function updateDisplay(secRemaining) {
   const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
   const secs = String(secRemaining % 60).padStart(2, '0');
@@ -45,9 +73,9 @@ function frame(timestamp) {
   } else {
     paused = true;
     timeEl.classList.add('complete');
+    capturePokemon();
     if (!isBreak) {
       launchConfetti();
-      capturePokemon();
       isBreak = true;
       duration = breakDuration;
       remaining = duration;
@@ -98,6 +126,8 @@ resetBtn.addEventListener('click', () => {
 function applyDurations() {
   workDuration = Math.max(parseInt(workInput.value, 10) || 1, 1) * 60;
   breakDuration = Math.max(parseInt(breakInput.value, 10) || 1, 1) * 60;
+  localStorage.setItem('work-duration', workInput.value);
+  localStorage.setItem('break-duration', breakInput.value);
   if (!isBreak) {
     duration = workDuration;
   } else {

--- a/style.css
+++ b/style.css
@@ -318,26 +318,11 @@ textarea:focus {
 #entries .entry.expanded .media {
   max-height: 1000px;
 }
-
-=======
-}
-
-#entries .entry.expanded .full,
-#entries .entry.expanded .media {
-  max-height: 1000px;
-}
-
 #entries .entry .media img,
 #entries .entry .media video {
   display: block;
   max-width: 100%;
   border-radius: 8px;
-}
-
-#entries .entry .media video {
-  max-height: 400px;
-}
-
 }
 
 #entries .entry .media video {
@@ -373,6 +358,27 @@ textarea:focus {
   border: 2px solid #000;
   border-radius: 4px;
   background: #fff;
+}
+
+.stats {
+  text-align: center;
+  margin-top: 0.75rem;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 0.65rem;
+}
+
+.capture-toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: 2px solid #000;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 0.75rem;
+  animation: toast 3s forwards;
 }
 
 @keyframes fadeIn {
@@ -485,65 +491,14 @@ textarea:focus {
   100% {
     transform: translateX(calc(100vw + 60px));
   }
+}
 
-body {
-  font-family: Arial, sans-serif;
-  margin: 0;
-  padding: 0;
-  background: var(--bg, #fff);
-  color: var(--fg, #000);
-}
-header {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  padding: 1rem;
-  background: var(--header-bg, #eee);
-}
-#timeline {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
-}
-.entry {
-  border: 1px solid #ccc;
-  padding: 1rem;
-  border-radius: 8px;
-  background: var(--entry-bg, #fafafa);
-}
-.entry img, .entry video {
-  max-width: 100%;
-  display: block;
-  margin-top: 0.5rem;
-}
-.modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.5);
-  display: none;
-  align-items: center;
-  justify-content: center;
-}
-.modal-content {
-  background: #fff;
-  padding: 1rem;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 500px;
-}
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 1rem;
-}
-.dark {
-  --bg: #121212;
-  --fg: #eee;
-  --header-bg: #1e1e1e;
-  --entry-bg: #1e1e1e;
+@keyframes toast {
+  0%, 80% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(10px);
+  }
 }


### PR DESCRIPTION
## Summary
- allow selecting work and break minutes from dropdowns
- selections persist across sessions using localStorage
- capture a new random Pokémon every time any timer completes

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895097a2da0832499004df86c7b355e