### PR TITLE
Fix timer dropdown initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,37 +58,6 @@ duration = workDuration;
 remaining = duration;
 totalMs = duration * 1000;
 
-xe5vmk-codex/add-adjustable-timer-for-pokemon-capture
-function populateDropdown(select, defaultValue) {
-  for (let i = 1; i <= 60; i++) {
-    const option = document.createElement('option');
-    option.value = i;
-    option.textContent = i;
-    select.appendChild(option);
-  }
-  select.value = defaultValue;
-}
-
-populateDropdown(workInput, 25);
-populateDropdown(breakInput, 5);
-
-
-main
-// Load saved durations or fall back to defaults
-const savedWork = parseInt(localStorage.getItem('work-duration'), 10);
-const savedBreak = parseInt(localStorage.getItem('break-duration'), 10);
-if (!isNaN(savedWork)) {
-  workDuration = savedWork * 60;
-  workInput.value = savedWork;
-}
-if (!isNaN(savedBreak)) {
-  breakDuration = savedBreak * 60;
-  breakInput.value = savedBreak;
-}
-duration = workDuration;
-remaining = duration;
-totalMs = duration * 1000;
-
 function updateDisplay(secRemaining) {
   const mins = String(Math.floor(secRemaining / 60)).padStart(2, '0');
   const secs = String(secRemaining % 60).padStart(2, '0');

--- a/style.css
+++ b/style.css
@@ -161,7 +161,7 @@ main > section:nth-of-type(2) {
   font-size: 0.65rem;
 }
 
-.duration-settings input {
+.duration-settings select {
   width: 4rem;
   margin-top: 0.25rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- clean up Pomodoro timer script and ensure duration dropdown loads only once
- style duration dropdown to match other inputs

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689522c2ea248324b10bfca97cb16b18