### PR TITLE
feat: add pokedex themed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,22 +17,24 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <div class="pokeball-wrapper">
-      <div class="pokeball" aria-hidden="true"></div>
-    </div>
-    <h1>PokéJournal</h1>
-    <p class="tagline">Catch your thoughts &amp; train your focus</p>
-  </header>
-  <img
-    id="background-pokemon"
-    src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
-    class="runner"
-    alt=""
-    aria-hidden="true"
-  />
+  <div class="pokedex">
+    <div class="screen">
+      <header>
+        <div class="pokeball-wrapper">
+          <div class="pokeball" aria-hidden="true"></div>
+        </div>
+        <h1>PokéJournal</h1>
+        <p class="tagline">Catch your thoughts &amp; train your focus</p>
+      </header>
+      <img
+        id="background-pokemon"
+        src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
+        class="runner"
+        alt=""
+        aria-hidden="true"
+      />
 
-  <main>
+      <main>
     <section id="timer">
       <h2>Pomodoro Timer</h2>
       <div id="time-wrapper">
@@ -78,7 +80,9 @@
       </div>
       <div id="entries"></div>
     </section>
-  </main>
+      </main>
+    </div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 :root {
-  --bg-start: #fff8e1;
-  --bg-end: #ffe5e5;
-  --text: #1f2937;
-  --accent: #ef4444;
-  --accent-hover: #dc2626;
-  --card: #ffffff;
-  --border: #e5e7eb;
+  --bg-start: #e00000;
+  --bg-end: #9b0000;
+  --text: #0f380f;
+  --accent: #e00000;
+  --accent-hover: #b00000;
+  --screen: #9bbc0f;
+  --card: #cfe9a6;
+  --border: #0f380f;
   --complete: #ffcb05;
 }
 
@@ -15,19 +16,30 @@
 
 body {
   margin: 0;
-  font-family: 'Inter', sans-serif;
-  background:
-    linear-gradient(135deg, var(--bg-start), var(--bg-end)),
-    radial-gradient(circle at 20px 20px, #fff 0 9px, #000 9px 10px, var(--accent) 10px 19px, #000 19px 20px);
-  background-size: 100% 100%, 40px 40px;
-  animation: scrollBg 30s linear infinite;
+  font-family: 'Press Start 2P', cursive;
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
   color: var(--text);
   line-height: 1.6;
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
   min-height: 100vh;
-  padding: 0 1rem;
+  padding: 1rem;
+}
+
+.pokedex {
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
+  border: 8px solid #111;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: inset -6px -6px 0 rgba(0, 0, 0, 0.3);
+}
+
+.screen {
+  background: var(--screen);
+  border: 4px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 header {
@@ -110,7 +122,7 @@ section {
   background: var(--card);
   padding: 1.75rem;
   border-radius: 12px;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.2s;
   opacity: 0;
@@ -200,7 +212,7 @@ main > section:nth-of-type(2) {
 button {
   background: var(--accent);
   color: #fff;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
   padding: 0.5rem 1.25rem;
   border-radius: 6px;
   cursor: pointer;
@@ -266,7 +278,7 @@ input[type="file"] {
 .media-preview video {
   max-width: 100%;
   border-radius: 8px;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
 }
 
 .error {
@@ -291,7 +303,7 @@ textarea:focus {
 }
 
 #entries .entry:hover {
-  background: #f9fafb;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 #entries .entry:last-child {


### PR DESCRIPTION
## Summary
- Wrap app in Pokedex screen container for retro feel
- Add Gameboy-inspired color palette and device styling
- Tune section and button styles to match the new theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689531b192588324a6f6b0bbd4422865