### PR TITLE
feat: add starter selection and pokeball timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,22 +17,24 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header>
-    <div class="pokeball-wrapper">
-      <div class="pokeball" aria-hidden="true"></div>
-    </div>
-    <h1>PokéJournal</h1>
-    <p class="tagline">Catch your thoughts &amp; train your focus</p>
-  </header>
-  <img
-    id="background-pokemon"
-    src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
-    class="runner"
-    alt=""
-    aria-hidden="true"
-  />
+  <div class="pokedex">
+    <div class="screen">
+      <header>
+        <div class="pokeball-wrapper">
+          <div class="pokeball" aria-hidden="true"></div>
+        </div>
+        <h1>PokéJournal</h1>
+        <p class="tagline">Catch your thoughts &amp; train your focus</p>
+      </header>
+      <img
+        id="background-pokemon"
+        src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"
+        class="runner"
+        alt=""
+        aria-hidden="true"
+      />
 
-  <main>
+      <main>
     <section id="timer">
       <h2>Pomodoro Timer</h2>
       <div id="time-wrapper">
@@ -75,10 +77,22 @@
         <div id="media-preview" class="media-preview" aria-hidden="true"></div>
         <p id="error" class="error" aria-live="polite"></p>
         <button id="save-entry">Save Entry</button>
-      </div>
-      <div id="entries"></div>
+  </div>
+  <div id="entries"></div>
     </section>
-  </main>
+      </main>
+    </div>
+  </div>
+  <div id="starter-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Choose your starter!</h2>
+      <div class="starters">
+        <img data-id="1" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png" alt="Bulbasaur" />
+        <img data-id="4" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png" alt="Charmander" />
+        <img data-id="7" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png" alt="Squirtle" />
+      </div>
+    </div>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -384,6 +384,7 @@ function launchConfetti() {
 
 const runnerImg = document.getElementById('background-pokemon');
 const capturedEl = document.getElementById('captured');
+const starterModal = document.getElementById('starter-modal');
 let captured = JSON.parse(localStorage.getItem('captured-pokemon') || '[]').map(p => ({
   id: p.id || null,
   name: p.name,
@@ -396,6 +397,17 @@ if (isNaN(activePokemonIndex)) activePokemonIndex = null;
 renderCaptured();
 updateRunner();
 
+if (captured.length === 0 && starterModal) {
+  starterModal.classList.remove('hidden');
+}
+
+starterModal?.addEventListener('click', e => {
+  const img = e.target.closest('img[data-id]');
+  if (!img) return;
+  const id = parseInt(img.dataset.id, 10);
+  chooseStarter(id);
+});
+
 capturedEl.addEventListener('click', e => {
   const img = e.target.closest('img');
   if (!img) return;
@@ -403,6 +415,24 @@ capturedEl.addEventListener('click', e => {
   if (isNaN(index)) return;
   setActivePokemon(index);
 });
+
+function chooseStarter(id) {
+  const starters = {
+    1: { name: 'bulbasaur', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png' },
+    4: { name: 'charmander', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png' },
+    7: { name: 'squirtle', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png' }
+  };
+  const base = starters[id];
+  if (!base) return;
+  const pokemon = { id, name: base.name, sprite: base.sprite, xp: 0, level: 1 };
+  captured.push(pokemon);
+  activePokemonIndex = captured.length - 1;
+  localStorage.setItem('captured-pokemon', JSON.stringify(captured));
+  localStorage.setItem('active-pokemon-index', activePokemonIndex);
+  renderCaptured();
+  updateRunner();
+  starterModal?.classList.add('hidden');
+}
 
 async function capturePokemon() {
   try {

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 :root {
-  --bg-start: #fff8e1;
-  --bg-end: #ffe5e5;
-  --text: #1f2937;
-  --accent: #ef4444;
-  --accent-hover: #dc2626;
-  --card: #ffffff;
-  --border: #e5e7eb;
+  --bg-start: #e00000;
+  --bg-end: #9b0000;
+  --text: #0f380f;
+  --accent: #e00000;
+  --accent-hover: #b00000;
+  --screen: #9bbc0f;
+  --card: #cfe9a6;
+  --border: #0f380f;
   --complete: #ffcb05;
 }
 
@@ -15,19 +16,30 @@
 
 body {
   margin: 0;
-  font-family: 'Inter', sans-serif;
-  background:
-    linear-gradient(135deg, var(--bg-start), var(--bg-end)),
-    radial-gradient(circle at 20px 20px, #fff 0 9px, #000 9px 10px, var(--accent) 10px 19px, #000 19px 20px);
-  background-size: 100% 100%, 40px 40px;
-  animation: scrollBg 30s linear infinite;
+  font-family: 'Press Start 2P', cursive;
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
   color: var(--text);
   line-height: 1.6;
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
   min-height: 100vh;
-  padding: 0 1rem;
+  padding: 1rem;
+}
+
+.pokedex {
+  background: linear-gradient(180deg, var(--bg-start), var(--bg-end));
+  border: 8px solid #111;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: inset -6px -6px 0 rgba(0, 0, 0, 0.3);
+}
+
+.screen {
+  background: var(--screen);
+  border: 4px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 header {
@@ -110,7 +122,7 @@ section {
   background: var(--card);
   padding: 1.75rem;
   border-radius: 12px;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
   transition: box-shadow 0.2s;
   opacity: 0;
@@ -134,6 +146,35 @@ main > section:nth-of-type(2) {
   width: 150px;
   height: 150px;
   margin: 1rem auto;
+  border: 4px solid #000;
+  border-radius: 50%;
+  overflow: hidden;
+  background: linear-gradient(to bottom, var(--accent) 50%, #fff 50%);
+}
+
+#time-wrapper::before {
+  content: '';
+  position: absolute;
+  top: calc(50% - 2px);
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background: #000;
+  z-index: 2;
+}
+
+#time-wrapper::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  background: #fff;
+  border: 4px solid #000;
+  border-radius: 50%;
+  z-index: 3;
 }
 
 #timer #time {
@@ -144,6 +185,7 @@ main > section:nth-of-type(2) {
   font-size: 3.5rem;
   font-variant-numeric: tabular-nums;
   text-align: center;
+  z-index: 4;
 }
 
 .duration-settings {
@@ -171,9 +213,13 @@ main > section:nth-of-type(2) {
 }
 
 #progress {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   transform: rotate(-90deg);
+  z-index: 1;
 }
 
 #progress circle {
@@ -186,7 +232,7 @@ main > section:nth-of-type(2) {
 }
 
 #progress circle.bar {
-  stroke: var(--accent);
+  stroke: var(--border);
   stroke-dasharray: 282.743px;
   stroke-dashoffset: 0;
 }
@@ -200,7 +246,7 @@ main > section:nth-of-type(2) {
 button {
   background: var(--accent);
   color: #fff;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
   padding: 0.5rem 1.25rem;
   border-radius: 6px;
   cursor: pointer;
@@ -266,7 +312,7 @@ input[type="file"] {
 .media-preview video {
   max-width: 100%;
   border-radius: 8px;
-  border: 2px solid #000;
+  border: 2px solid var(--border);
 }
 
 .error {
@@ -291,7 +337,7 @@ textarea:focus {
 }
 
 #entries .entry:hover {
-  background: #f9fafb;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 #entries .entry:last-child {
@@ -511,6 +557,35 @@ textarea:focus {
   100% {
     transform: translateX(calc(100vw + 60px));
   }
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: var(--screen);
+  border: 4px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.starters img {
+  width: 72px;
+  margin: 0 0.5rem;
+  cursor: pointer;
+  image-rendering: pixelated;
+}
+
+.hidden {
+  display: none;
 }
 
 @keyframes toast {


### PR DESCRIPTION
## Summary
- style countdown display as a Pokéball with central button and progress ring
- prompt new users to pick a starter Pokémon before using the app
- wire up starter selection to set the active Pokémon and update the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689531b192588324a6f6b0bbd4422865