### PR TITLE
Ensure site loads latest version without hard refresh

### DIFF
--- a/script.js
+++ b/script.js
@@ -493,6 +493,12 @@ function updateRunner() {
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('sw.js');
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
 }
 
 if ('Notification' in window && Notification.permission === 'default') {


### PR DESCRIPTION
## Summary
- Rework service worker to activate immediately, clean old caches, and fetch network-first while caching updates.
- Automatically reload the page when a new service worker takes control so users always see the latest version.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895365baca48324a10beb177dc9e12a