### PR TITLE
Add XP gating for new Pokémon and clean markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       <div class="stats">
         <p>Total Focus: <span id="total-focus">0</span> min</p>
         <p>Sessions: <span id="session-count">0</span></p>
+        <p>XP: <span id="xp">0</span></p>
       </div>
     </section>
 
@@ -77,13 +78,12 @@
         <div id="media-preview" class="media-preview" aria-hidden="true"></div>
         <p id="error" class="error" aria-live="polite"></p>
         <button id="save-entry">Save Entry</button>
-  </div>
-  <div id="entries"></div>
+      </div>
+      <div id="entries"></div>
     </section>
       </main>
     </div>
   </div>
-tg1rpx-codex/update-website-theme-to-retro-pokedex-style
   <div id="starter-modal" class="modal hidden">
     <div class="modal-content">
       <h2>Choose your starter!</h2>
@@ -94,7 +94,6 @@ tg1rpx-codex/update-website-theme-to-retro-pokedex-style
       </div>
     </div>
   </div>
-main
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -21,13 +21,18 @@ const workInput = document.getElementById('work-duration');
 const breakInput = document.getElementById('break-duration');
 const totalFocusEl = document.getElementById('total-focus');
 const sessionCountEl = document.getElementById('session-count');
+const xpEl = document.getElementById('xp');
+
+const XP_THRESHOLD = 30; // minutes required to catch a new Pokémon
 
 let totalFocus = parseInt(localStorage.getItem('total-focus'), 10) || 0;
 let sessionCount = parseInt(localStorage.getItem('session-count'), 10) || 0;
+let xp = parseInt(localStorage.getItem('xp'), 10) || 0;
 
 function renderStats() {
   if (totalFocusEl) totalFocusEl.textContent = totalFocus;
   if (sessionCountEl) sessionCountEl.textContent = sessionCount;
+  if (xpEl) xpEl.textContent = xp;
 }
 
 function populateDropdown(select, defaultValue) {
@@ -85,11 +90,18 @@ function frame(timestamp) {
     timeEl.classList.add('complete');
     if (!isBreak) {
       trainActivePokemon();
-      capturePokemon();
-      totalFocus += workDuration / 60;
+      const gained = workDuration / 60;
+      xp += gained;
+      totalFocus += gained;
       sessionCount += 1;
+      localStorage.setItem('xp', xp);
       localStorage.setItem('total-focus', totalFocus);
       localStorage.setItem('session-count', sessionCount);
+      while (xp >= XP_THRESHOLD) {
+        capturePokemon();
+        xp -= XP_THRESHOLD;
+        localStorage.setItem('xp', xp);
+      }
       renderStats();
       launchConfetti();
       isBreak = true;


### PR DESCRIPTION
## Summary
- remove stray branch name text from HTML layout
- track XP from focus sessions and only capture Pokémon after enough XP

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953a1f10b883248b094031194d9b30